### PR TITLE
Enable LUA headers and logs

### DIFF
--- a/Dockerfile-trunk-nginx
+++ b/Dockerfile-trunk-nginx
@@ -45,9 +45,9 @@ RUN sed -i "s/logLevel\s*=\s*warn/logLevel = debug/" /etc/lemonldap-ng/lemonldap
 # Enable sites
 RUN cd /etc/nginx/sites-enabled && ln -s ../sites-available/portal-nginx.conf && ln -s ../sites-available/manager-nginx.conf  && ln -s ../sites-available/handler-nginx.conf && ln -s ../sites-available/test-nginx.conf
 
-# Set HTTP header Auth-User
-RUN sed -i 's/#auth_request_set/auth_request_set/' /etc/lemonldap-ng/test-nginx.conf
-RUN sed -i 's/#fastcgi_param/fastcgi_param/' /etc/lemonldap-ng/test-nginx.conf
+# Enable headers and custom logs
+RUN perl -i -pe 's/#// if(/nginx-lua-headers/)' /etc/lemonldap-ng/test-nginx.conf
+RUN perl -i -pe 's/#// if(/access\.log/)' /etc/lemonldap-ng/handler-nginx.conf
 
 # No daemon
 RUN echo "\ndaemon off;" >> /etc/nginx/nginx.conf


### PR DESCRIPTION
I've fixed Debian stable support in LLNG trunk. Now we can enable LUA handler and custom logs